### PR TITLE
Update sub to ref for override aliases to fix breaking change

### DIFF
--- a/cloudfront.cfndsl.rb
+++ b/cloudfront.cfndsl.rb
@@ -106,7 +106,7 @@ CloudFormation do
     Mapping('aliases', map)
     distribution_config[:Aliases] = FnSplit(',', FnFindInMap('aliases', Ref('AliasMap'), 'records'))
   elsif aliases.any?
-    distribution_config[:Aliases] = FnIf('OverrideAliases', FnSplit(',', FnSub('${OverrideAliases}')), aliases.map { |a| FnSub(a) })
+    distribution_config[:Aliases] = FnIf('OverrideAliases', FnSplit(',', Ref('OverrideAliases')), aliases.map { |a| FnSub(a) })
   end
 
   CloudFront_Distribution(:Distribution) {


### PR DESCRIPTION
Using a sub here breaks the s3-cloudfront component when it specifies the `aliases` config since because its an inline component a stack update will instantly fail for this reason:

```
Template format error: Unresolved resource dependencies [OverrideAliases] in the Resources block of the template
```

Since the s3-cloudfront component prefixes inlined component parameters with the component name before it's able to be used by the inlined stack, using a sub throws the above error.

Referencing the parameter here instead of a sub should resolve this.