### PR TITLE
Add DistributionId to exports

### DIFF
--- a/cloudfront.cfndsl.rb
+++ b/cloudfront.cfndsl.rb
@@ -155,4 +155,9 @@ CloudFormation do
     Export FnSub("${EnvironmentName}-#{external_parameters[:export_name]}-DomainName")
   end
 
+  Output('DistributionId') do
+    Value(FnGetAtt('Distribution', 'Id'))
+    Export FnSub("${EnvironmentName}-#{external_parameters[:export_name]}-DistributionId")
+  end
+
 end


### PR DESCRIPTION
Need DistributionId for certain actions so having it as an export would make it much easier to retrieve per stack.