### PR TITLE
Fix naming and continue to improve

### DIFF
--- a/cloudfront.cfhighlander.rb
+++ b/cloudfront.cfhighlander.rb
@@ -4,11 +4,9 @@ CfhighlanderTemplate do
     ComponentParam 'EnvironmentName', 'dev', isGlobal: true
     ComponentParam 'EnvironmentType', 'development', allowedValues: ['development','production'], isGlobal: true
     ComponentParam 'DnsDomain', isGlobal: true
-    ComponentParam 'EnableLambdaFunctionAssociations', 'false', allowedValues: ['true', 'false']
 
     origins.each do |id,config|
       ComponentParam "#{id}OriginDomainName"
-      ComponentParam "#{id}OriginAccessIdentityInput", '' if config['source'] == 's3'
     end if (defined? origins) && (origins.any?)
 
     case ssl['type']
@@ -31,6 +29,5 @@ CfhighlanderTemplate do
     ComponentParam 'OverrideAliases', ''
 
   end
-
 
 end

--- a/cloudfront.cfhighlander.rb
+++ b/cloudfront.cfhighlander.rb
@@ -21,6 +21,11 @@ CfhighlanderTemplate do
     ComponentParam 'MinTTL',      0
     ComponentParam 'MaxTTL',      31536000
     ComponentParam 'DefaultTTL',  86400
+
+    if (defined? aliases_map) && (aliases_map.any?)
+      ComponentParam 'AliasMap', aliases_map.keys[0], allowedValues: aliases_map.map { |k,v| k }
+    end
+    
     ComponentParam 'OverrideAliases', ''
 
   end

--- a/cloudfront.cfhighlander.rb
+++ b/cloudfront.cfhighlander.rb
@@ -21,11 +21,6 @@ CfhighlanderTemplate do
     ComponentParam 'MinTTL',      0
     ComponentParam 'MaxTTL',      31536000
     ComponentParam 'DefaultTTL',  86400
-
-    if (defined? aliases_map) && (aliases_map.any?)
-      ComponentParam 'AliasMap', aliases_map.keys[0], allowedValues: aliases_map.map { |k,v| k }
-    end
-
     ComponentParam 'OverrideAliases', ''
 
   end

--- a/cloudfront.cfndsl.rb
+++ b/cloudfront.cfndsl.rb
@@ -221,7 +221,7 @@ CloudFormation do
     map = {}
     aliases_map.each { |k,v| map[k.to_sym] = { records: v.join(',') } }
     Mapping('aliases', map)
-    distribution_config[:Aliases] = FnSplit(',', FnFindInMap('aliases', Ref('EnvironmentName'), 'records'))
+    distribution_config[:Aliases] = FnSplit(',', FnFindInMap('aliases', Ref('AliasMap'), 'records'))
   elsif aliases.any?
     distribution_config[:Aliases] = FnIf('OverrideAliases', FnSplit(',', Ref('OverrideAliases')), aliases.map { |a| FnSub(a) })
   end

--- a/cloudfront.cfndsl.rb
+++ b/cloudfront.cfndsl.rb
@@ -109,7 +109,7 @@ CloudFormation do
     map = {}
     aliases_map.each { |k,v| map[k.to_sym] = { records: v.join(',') } }
     Mapping('aliases', map)
-    distribution_config[:Aliases] = FnSplit(',', FnFindInMap('aliases', Ref('AliasMap'), 'records'))
+    distribution_config[:Aliases] = FnSplit(',', FnFindInMap('aliases', Ref('EnvironmentName'), 'records'))
   elsif aliases.any?
     distribution_config[:Aliases] = FnIf('OverrideAliases', FnSplit(',', Ref('OverrideAliases')), aliases.map { |a| FnSub(a) })
   end

--- a/tests/dns_format.test.yaml
+++ b/tests/dns_format.test.yaml
@@ -1,25 +1,25 @@
 test_metadata:
-type: config
-name: dns format
-description: Create CNAME DNS records with a custom format
+  type: config
+  name: dns format
+  description: Create CNAME DNS records with a custom format
 
 test_parameters:
-DnsPrefix: custom-prefix
+  DnsPrefix: custom-prefix
 
 dns_format: # ${EnvironmentName}.${DnsDomain}
-Fn::Join:
-  - '.'
-  - - Ref: DnsPrefix
-    - Ref: DnsDomain
+  Fn::Join:
+    - '.'
+    - - Ref: DnsPrefix
+      - Ref: DnsDomain
 
 dns_records:
-- apex
-- mycdn
+  - apex
+  - mycdn
 
 origins:
-myapploadbalancer:
-  source: loadbalancer
-  # http-only | match-viewer | https-only
-  protocol_policy: https-only
-  ssl_protocols:
-    - TLSv1.2
+  myapploadbalancer:
+    source: loadbalancer
+    # http-only | match-viewer | https-only
+    protocol_policy: https-only
+    ssl_protocols:
+      - TLSv1.2

--- a/tests/dns_format.test.yaml
+++ b/tests/dns_format.test.yaml
@@ -1,0 +1,25 @@
+test_metadata:
+type: config
+name: dns format
+description: Create CNAME DNS records with a custom format
+
+test_parameters:
+DnsPrefix: custom-prefix
+
+dns_format: # ${EnvironmentName}.${DnsDomain}
+Fn::Join:
+  - '.'
+  - - Ref: DnsPrefix
+    - Ref: DnsDomain
+
+dns_records:
+- apex
+- mycdn
+
+origins:
+myapploadbalancer:
+  source: loadbalancer
+  # http-only | match-viewer | https-only
+  protocol_policy: https-only
+  ssl_protocols:
+    - TLSv1.2


### PR DESCRIPTION
* Allow the use of custom value (``DnsPrefix``) instead of globally defined (``EnvironmentName``)
* Use ``EnvironmentName`` as ``FindInMap`` selector. Now ``aliases_map`` does work.
* Use ``AccessControl`` by default instead of ``AccessIdentity``
* Behavior's ``cache policies`` & ``origin request policies``
* Added ``FunctionAssociation``